### PR TITLE
Update template

### DIFF
--- a/__template__/as-pect.asconfig.json
+++ b/__template__/as-pect.asconfig.json
@@ -1,0 +1,24 @@
+{
+    "targets": {
+      "coverage": {
+        "lib": ["./node_modules/@as-covers/assembly/index.ts"],
+        "transform": ["@as-covers/transform", "@as-pect/transform"]
+      },
+      "noCoverage": {
+        "transform": ["@as-pect/transform"]
+      }
+    },
+    "options": {
+      "exportMemory": true,
+      "outFile": "output.wasm",
+      "textFile": "output.wat",
+      "bindings": "raw",
+      "exportStart": "_start",
+      "exportRuntime": true,
+      "use": ["RTRACE=1", "BUILD_FOR_TESTING=0"],
+      "debug": true,
+      "exportTable": true
+    },
+    "extends": "./asconfig.json",
+    "entries": ["./node_modules/@as-pect/assembly/assembly/index.ts"]
+  }

--- a/__template__/as-pect.config.js
+++ b/__template__/as-pect.config.js
@@ -1,48 +1,44 @@
-const path = require('path');
-const { MockVM } = require('@koinos/mock-vm');
+import { MockVM } from '@koinos/mock-vm';
 
-module.exports = {
+export default {
   /**
    * A set of globs passed to the glob package that qualify typescript files for testing.
    */
-  include: ["assembly/__tests__/**/*.spec.ts"],
+  entries: ["assembly/__tests__/**/*.spec.ts"],
+
   /**
    * A set of globs passed to the glob package that quality files to be added to each test.
    */
-  add: ["assembly/__tests__/**/*.include.ts"],
-  /**
-   * All the compiler flags needed for this test suite. Make sure that a binary file is output.
-   */
-  flags: {
-    /** To output a wat file, uncomment the following line. */
-    // "--textFile": ["output.wat"],
-    /** A runtime must be provided here. */
-    "--runtime": ["incremental"], // Acceptable values are: "incremental", "minimal", and "stub"
-  },
+  include: ["assembly/__tests__/**/*.include.ts"],
   /**
    * A set of regexp that will disclude source files from testing.
    */
-  disclude: [/node_modules/],
+  disclude: [/node_modules/i],
+
   /**
    * Add your required AssemblyScript imports here.
    */
-  imports(memory, createImports, instantiateSync, binary) {
+  async instantiate(memory, createImports, instantiate, binary) {
     let instance; // Imports can reference this
     const mockVM = new MockVM();
 
     const myImports = {
       wasi_snapshot_preview1: {
-        fd_write: () => { },
-        proc_exit: () => { }
+        fd_write: () => {},
+        proc_exit: () => {}
       },
       // put your web assembly imports here, and return the module
       env: {
         ...mockVM.getImports()
       }
     };
-    instance = instantiateSync(binary, createImports(myImports));
-    instance.exports.memory.grow(512);
-    mockVM.setInstance(instance);
+    instance = instantiate(binary, createImports(myImports));
+
+    instance.then(function (result) {
+      result.exports.memory.grow(512);
+      mockVM.setInstance(result);
+    });
+
     return instance;
   },
   // wasi: {

--- a/__template__/jest.config.js
+++ b/__template__/jest.config.js
@@ -1,0 +1,6 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+export default {
+    preset: 'ts-jest',
+    testEnvironment: 'node',
+    rootDir: 'tests'
+  };

--- a/__template__/package.json
+++ b/__template__/package.json
@@ -2,6 +2,7 @@
   "name": "##_PROTO_PACKAGE_##",
   "version": "0.1.0",
   "license": "MIT",
+  "type": "module",
   "dependencies": {
   },
   "devDependencies": {


### PR DESCRIPTION

## Brief description
Fixes project template.

## Checklist

- [x] I have built this pull request locally
- [x] I have ran the unit tests locally
- [x] I have manually tested this pull request
- [x] I have reviewed my pull request
- [ ] I have added any relevant tests

## Demonstration
```sh
koinos-sdk-as-cli create token2
cd token2
yarn install && yarn build:debug && yarn test

Running tests...
yarn asp --verbose --config as-pect.config.js
$ /home/sgerbino/Workspace/token2/node_modules/.bin/asp --verbose --config as-pect.config.js
       ___   _____                       __    
      /   | / ___/      ____  ___  _____/ /_   
     / /| | \__ \______/ __ \/ _ \/ ___/ __/   
    / ___ |___/ /_____/ /_/ /  __/ /__/ /_     
   /_/  |_/____/     / .___/\___/\___/\__/     
                    /_/                        

⚡AS-pect⚡ Test suite runner [8.1.0]
Using config: /home/sgerbino/Workspace/token2/as-pect.config.js
ASC Version: 0.27.29
[Log]Using code coverage: assembly/*.ts
[Log]Using coverage: assembly/*.ts
[Describe]: contract

[Log] Hello, World!
 [Success]: ✔ should return 'hello, NAME!'

    [File]: assembly/__tests__/Token2.spec.ts
  [Groups]: 2 pass, 2 total
  [Result]: ✔ PASS
[Snapshot]: 0 total, 0 added, 0 removed, 0 different
 [Summary]: 1 pass,  0 fail, 1 total
    [Time]: 30.332ms

~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Coverage Report:

┌────────────────────┬───────┬───────┬──────┬──────┬───────────┐
│ File               │ Total │ Block │ Func │ Expr │ Uncovered │
├────────────────────┼───────┼───────┼──────┼──────┼───────────┤
│ assembly/Token2.ts │ 100%  │ 100%  │ 100% │ N/A  │           │
├────────────────────┼───────┼───────┼──────┼──────┼───────────┤
│ total              │ 100%  │ 100%  │ 100% │ N/A  │           │
└────────────────────┴───────┴───────┴──────┴──────┴───────────┘

  [Summary]
    [Tests]: 1 / 1
   [Groups]: 2 / 2
[Snapshots]: 0 / 0, Added 0, Changed 0
   [Result]: ✔ Pass!

Done in 1.60s.
```
